### PR TITLE
Update loader-utils & specify correct dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,13 @@
     "test": "mocha",
     "build-sample": "webpack --config ./sample/webpack.config.js"
   },
-  "devDependencies": {
+  "dependencies": {
     "fs": "0.0.2",
     "loader-utils": "^2.0.0",
-    "mocha": "^3.4.2",
     "path": "^0.12.7",
+  },
+  "devDependencies": {
+    "mocha": "^3.4.2",
     "webpack": "^2.6.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "fs": "0.0.2",
     "loader-utils": "^2.0.0",
-    "path": "^0.12.7",
+    "path": "^0.12.7"
   },
   "devDependencies": {
     "mocha": "^3.4.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "fs": "0.0.2",
-    "loader-utils": "^1.1.0",
+    "loader-utils": "^2.0.0",
     "mocha": "^3.4.2",
     "path": "^0.12.7",
     "webpack": "^2.6.1"


### PR DESCRIPTION
Hey @joeyeng 

I faced with a problem that contenthash-replace-webpack-plugin was generating contentHash which was different from what file-loader is creating. So the problem was in the loader-utils that are kinda outdated in the plugin. Besides, I changed package.json so it reflects it's dependencies correctly.